### PR TITLE
feat: removes requirement for a DisplayName

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = {
     ],
     "prefer-template": "error",
     "prettier/prettier": "error",
+    "react/display-name": "off",
     "react-hooks/exhaustive-deps": "warn",
     "react-hooks/rules-of-hooks": "error",
     "react/jsx-curly-brace-presence": [


### PR DESCRIPTION
We don't use a `DisplayName` in our components at this time so this just leads to unnecessary warnings. If we want to intentionally start taking advantage of React's `DisplayName` we can add this rule back. 